### PR TITLE
Screenshot data handling

### DIFF
--- a/src/lib/AnglesReporter.ts
+++ b/src/lib/AnglesReporter.ts
@@ -16,7 +16,8 @@ import { StepStates } from './models/enum/StepStates';
 import { Step } from './models/Step';
 import { ScreenshotPlatform } from './models/requests/ScreenshotPlatform';
 import { Execution } from './models/Execution';
-import {ScreenshotDetails} from "./models/ScreenshotDetails";
+import {UpdateScreenshot} from "./models/requests/UpdateScreenshot";
+import {StoreScreenshotHeaders} from "./models/requests/StoreScreenshotHeaders";
 
 export class AnglesReporterClass {
   private static _instance: AnglesReporterClass = new AnglesReporterClass();
@@ -114,21 +115,22 @@ export class AnglesReporterClass {
   public async saveScreenshot(
     filePath: string,
     view: string,
-    screenshotDetails: ScreenshotDetails,
-  ): Promise<Screenshot> {
-    const storeScreenshot = new StoreScreenshot();
-    storeScreenshot.buildId = this.currentBuild._id;
+    storeScreenshot: StoreScreenshot): Promise<Screenshot> {
+    const storeScreenshotHeaders = new StoreScreenshotHeaders();
+    storeScreenshotHeaders.buildId = this.currentBuild._id;
+    storeScreenshotHeaders.view = view;
+    storeScreenshotHeaders.timestamp = new Date();
+
     storeScreenshot.filePath =  path.resolve(filePath);
-    storeScreenshot.view = view;
-    storeScreenshot.timestamp = new Date();
+
     try {
-      return await this.screenshots.saveScreenshot(storeScreenshot, screenshotDetails);
+      return await this.screenshots.saveScreenshot(storeScreenshot, storeScreenshotHeaders);
     } catch (error) {
       this.error(error);
     }
   }
 
-  public async updateScreenshot(screenshotId: string, screenshotDetails: ScreenshotDetails): Promise<Screenshot> {
+  public async updateScreenshot(screenshotId: string, screenshotDetails: UpdateScreenshot): Promise<Screenshot> {
     return this.screenshots.updateScreenshot(screenshotId, screenshotDetails);
   }
 

--- a/src/lib/AnglesReporter.ts
+++ b/src/lib/AnglesReporter.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, {AxiosInstance, AxiosResponse} from 'axios';
 import path from 'path';
 import { TeamRequests } from './requests/TeamRequests';
 import { EnvironmentRequests } from './requests/EnvironmentRequests';
@@ -16,6 +16,7 @@ import { StepStates } from './models/enum/StepStates';
 import { Step } from './models/Step';
 import { ScreenshotPlatform } from './models/requests/ScreenshotPlatform';
 import { Execution } from './models/Execution';
+import {ScreenshotDetails} from "./models/ScreenshotDetails";
 
 export class AnglesReporterClass {
   private static _instance: AnglesReporterClass = new AnglesReporterClass();
@@ -110,14 +111,10 @@ export class AnglesReporterClass {
     return await this.executions.saveExecution(this.currentExecution);
   }
 
-  public async saveScreenshot(filePath: string, view: string): Promise<Screenshot> {
-    return await this.saveScreenshotWithPlatform(filePath, view, undefined);
-  }
-
-  public async saveScreenshotWithPlatform(
+  public async saveScreenshot(
     filePath: string,
     view: string,
-    platform: ScreenshotPlatform,
+    screenshotDetails: ScreenshotDetails,
   ): Promise<Screenshot> {
     const storeScreenshot = new StoreScreenshot();
     storeScreenshot.buildId = this.currentBuild._id;
@@ -125,10 +122,14 @@ export class AnglesReporterClass {
     storeScreenshot.view = view;
     storeScreenshot.timestamp = new Date();
     try {
-      return await this.screenshots.saveScreenshotWithPlatform(storeScreenshot, platform);
+      return await this.screenshots.saveScreenshot(storeScreenshot, screenshotDetails);
     } catch (error) {
       this.error(error);
     }
+  }
+
+  public async updateScreenshot(screenshotId: string, screenshotDetails: ScreenshotDetails): Promise<Screenshot> {
+    return this.screenshots.updateScreenshot(screenshotId, screenshotDetails);
   }
 
   public addAction(name: string) {

--- a/src/lib/AnglesReporter.ts
+++ b/src/lib/AnglesReporter.ts
@@ -113,15 +113,13 @@ export class AnglesReporterClass {
   }
 
   public async saveScreenshot(
-    filePath: string,
     view: string,
     storeScreenshot: StoreScreenshot): Promise<Screenshot> {
     const storeScreenshotHeaders = new StoreScreenshotHeaders();
     storeScreenshotHeaders.buildId = this.currentBuild._id;
     storeScreenshotHeaders.view = view;
     storeScreenshotHeaders.timestamp = new Date();
-
-    storeScreenshot.filePath =  path.resolve(filePath);
+    storeScreenshot.filePath =  path.resolve(storeScreenshot.filePath);
 
     try {
       return await this.screenshots.saveScreenshot(storeScreenshot, storeScreenshotHeaders);

--- a/src/lib/models/ScreenshotDetails.ts
+++ b/src/lib/models/ScreenshotDetails.ts
@@ -1,0 +1,6 @@
+import {ScreenshotPlatform} from "./requests/ScreenshotPlatform";
+
+export class ScreenshotDetails {
+  platform: ScreenshotPlatform;
+  tags: string[];
+}

--- a/src/lib/models/ScreenshotDetails.ts
+++ b/src/lib/models/ScreenshotDetails.ts
@@ -1,6 +1,0 @@
-import {ScreenshotPlatform} from "./requests/ScreenshotPlatform";
-
-export class ScreenshotDetails {
-  platform: ScreenshotPlatform;
-  tags: string[];
-}

--- a/src/lib/models/requests/StoreScreenshotHeaders.ts
+++ b/src/lib/models/requests/StoreScreenshotHeaders.ts
@@ -1,0 +1,5 @@
+export class StoreScreenshotHeaders {
+  buildId: string;
+  view: string;
+  timestamp: Date;
+}

--- a/src/lib/models/requests/UpdateScreenshot.ts
+++ b/src/lib/models/requests/UpdateScreenshot.ts
@@ -1,7 +1,6 @@
 import {ScreenshotPlatform} from "./ScreenshotPlatform";
 
-export class StoreScreenshot {
-  filePath: string;
+export class UpdateScreenshot {
   platform: ScreenshotPlatform;
   tags: string[];
 }

--- a/src/lib/requests/ScreenshotRequests.ts
+++ b/src/lib/requests/ScreenshotRequests.ts
@@ -4,7 +4,8 @@ import { BaseRequests } from './BaseRequests';
 import { Screenshot } from '../models/Screenshot';
 import { StoreScreenshot } from '../models/requests/StoreScreenshot';
 import { ScreenshotPlatform } from '../models/requests/ScreenshotPlatform';
-import { ScreenshotDetails } from '../models/ScreenshotDetails';
+import { UpdateScreenshot } from '../models/requests/UpdateScreenshot';
+import {StoreScreenshotHeaders} from "../models/requests/StoreScreenshotHeaders";
 
 export class ScreenshotRequests extends BaseRequests {
   private axios: AxiosInstance;
@@ -16,25 +17,23 @@ export class ScreenshotRequests extends BaseRequests {
     this.axios = axiosInstance;
   }
 
-  public async saveScreenshot(storeScreenshot: StoreScreenshot, screenshotDetails: ScreenshotDetails): Promise<Screenshot> {
+  public async saveScreenshot(storeScreenshot: StoreScreenshot, storeScreenshotHeaders: StoreScreenshotHeaders): Promise<Screenshot> {
     const formData = new FormData();
     const fullPath = this.path.resolve(storeScreenshot.filePath);
     const fileStream = this.fs.createReadStream(fullPath);
     formData.append('screenshot', fileStream);
-    if (screenshotDetails !== undefined) {
-      if (screenshotDetails.platform !== undefined) {
-        Object.entries(screenshotDetails.platform).forEach(([key, value]) => {
-          formData.append(key, value);
-        });
-      }
-      if (screenshotDetails.tags !== undefined) {
-        formData.append('tags', screenshotDetails.tags.toString());
-      }
+    if (storeScreenshot.platform !== undefined) {
+      Object.entries(storeScreenshot.platform).forEach(([key, value]) => {
+        formData.append(key, value);
+      });
+    }
+    if (storeScreenshot.tags !== undefined) {
+      formData.append('tags', storeScreenshot.tags.toString());
     }
     const headers = formData.getHeaders({
-      buildId: storeScreenshot.buildId,
-      view: storeScreenshot.view,
-      timestamp: storeScreenshot.timestamp.toISOString(),
+      buildId: storeScreenshotHeaders.buildId,
+      view: storeScreenshotHeaders.view,
+      timestamp: storeScreenshotHeaders.timestamp.toISOString(),
     });
     const response: AxiosResponse<Screenshot> = await this.axios.post<Screenshot>(`screenshot/`, formData, {
       headers,
@@ -42,7 +41,7 @@ export class ScreenshotRequests extends BaseRequests {
     return this.success(response);
   }
 
-  public async updateScreenshot(screenshotId: string, screenshotDetails: ScreenshotDetails): Promise<Screenshot> {
+  public async updateScreenshot(screenshotId: string, screenshotDetails: UpdateScreenshot): Promise<Screenshot> {
     const response: AxiosResponse<Screenshot> = await this.axios.put<Screenshot>(`screenshot/${screenshotId}`, screenshotDetails);
     return this.success(response);
   }


### PR DESCRIPTION
@snevesbarros 

Covered/Tested all scenario permutations of saving and updating a screenshot:

Saving a new screenshot 

- Provide platform details and tags
- Provide platform details only
- Provide tags only
- Provide neither tags or platform details

Updating an existing screenshot

- Provide platform details and tags
- Provide platform details only
- Provide tags only

Example usage of saving (can provide one or both details):
```
const storeScreenshot: StoreScreenshot = new StoreScreenshot();
storeScreenshot.filePath = screenshotPath;
storeScreenshot.platform = screenshotPlatform;
storeScreenshot.tags = screenshotTags;
const screenshot: Screenshot = await anglesReporter.saveScreenshot(screenshotView, storeScreenshot);
```

Example usage of updating (can provide one or both details):
```
const updateScreenshotDetails: UpdateScreenshot = new UpdateScreenshot();
updateScreenshotDetails.platform = screenshotPlatform;
updateScreenshotDetails.tags = screenshotTags;
await anglesReporter.updateScreenshot(screenshot._id, updateScreenshotDetails);
```

Both platform and tags
![Screenshot 2021-04-20 at 13 33 16](https://user-images.githubusercontent.com/3577952/115396512-f7f77980-a1dc-11eb-9a1f-4108874b65a8.png)

Tags only
![Screenshot 2021-04-20 at 13 33 34](https://user-images.githubusercontent.com/3577952/115396548-02b20e80-a1dd-11eb-8082-be3d5f184aba.png)

Platform only
![Screenshot 2021-04-20 at 13 46 59](https://user-images.githubusercontent.com/3577952/115398262-e4e5a900-a1de-11eb-8952-b51b5379597c.png)

Neither
![Screenshot 2021-04-20 at 13 33 45](https://user-images.githubusercontent.com/3577952/115396570-09408600-a1dd-11eb-93ee-ef6c6b35fd6c.png)


